### PR TITLE
Gateway JWT 토큰 파싱 및 헤더 추가 필터 구현

### DIFF
--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -28,7 +28,11 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// jwt
+	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AuthenticationFilter.java
+++ b/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.sparta.hotdeal.gateway.filter;
+
+import com.sparta.hotdeal.gateway.security.JwtUtil;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter implements GlobalFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        if (path.startsWith("/api/v1/auth")) {
+            return chain.filter(exchange);
+        }
+
+        String token = jwtUtil.extractToken(exchange);
+
+        if (token == null || !jwtUtil.validateToken(token)) {
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        // 토큰 검증 성공 시 헤더 덮어쓰기
+        Claims claims = jwtUtil.parseClaims(token);
+        // 새 요청 객체를 만들어서 헤더를 설정하고, 기존 exchange의 요청으로 교체
+        exchange = exchange.mutate()
+                .request(exchange.getRequest().mutate()
+                        .header("X-User-UserId", claims.get("userId", String.class))
+                        .header("X-User-Email", claims.get("email", String.class))
+                        .header("X-User-Role", claims.get("role", String.class))
+                        .build())
+                .build();
+
+        return chain.filter(exchange);
+    }
+}

--- a/gateway/src/main/java/com/sparta/hotdeal/gateway/security/JwtUtil.java
+++ b/gateway/src/main/java/com/sparta/hotdeal/gateway/security/JwtUtil.java
@@ -1,0 +1,62 @@
+package com.sparta.hotdeal.gateway.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Base64;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+    @Value("${service.jwt.secret-key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String extractToken(ServerWebExchange exchange) {
+        String authHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+}

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -43,3 +43,7 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
+
+service:
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}

--- a/user/src/main/java/com/sparta/hotdeal/user/application/service/AuthService.java
+++ b/user/src/main/java/com/sparta/hotdeal/user/application/service/AuthService.java
@@ -99,7 +99,7 @@ public class AuthService {
                         ErrorMessage.WRONG_EMAIL_OR_PASSWORD.getMessage()));
 
         return ResPostLoginDto.builder()
-                .accessToken(jwtUtil.createToken(user.getUserId(), user.getRole()))
+                .accessToken(jwtUtil.createToken(user.getUserId(), user.getEmail(), user.getRole()))
                 .refreshToken(null)
                 .build();
     }

--- a/user/src/main/java/com/sparta/hotdeal/user/application/util/JwtUtil.java
+++ b/user/src/main/java/com/sparta/hotdeal/user/application/util/JwtUtil.java
@@ -31,12 +31,13 @@ public class JwtUtil {
     }
 
     // 토큰 생성
-    public String createToken(UUID userId, UserRole role) {
+    public String createToken(UUID userId, String email, UserRole role) {
         Date date = new Date();
 
         return BEARER_PREFIX +
                 Jwts.builder()
-                        .claim("userId", userId) // 사용자 식별자값(userId)
+                        .claim("userId", userId.toString()) // 사용자 식별자값(userId)
+                        .claim("email", email)
                         .claim("role", role)
                         .setExpiration(new Date(date.getTime() + TOKEN_TIME)) // 만료 시간
                         .setIssuedAt(date) // 발급일


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/32/jwt-filter-gateway -> develop
### 이슈
- Resolves #32 
### Description
- 로그인 시 발급하는 토큰에 email 정보를 넣도록 변경
- JWT 파싱 기능 구현
- 헤더의 X-User-UserId, X-User-Email, X-User-Role에 각각의 정보를 포함시키는 필터 구현
### To Reviewers
- 비로그인으로 접근 가능한 부분은 필터를 수행하지 않도록 uri를 추가해야 하는데, 필요한 부분 코멘트 남겨주시면 반영하겠습니다!
