### PR TITLE
회원가입 Auditing 관련 버그 수정

### DIFF
--- a/user/src/main/java/com/sparta/hotdeal/user/application/service/AuthService.java
+++ b/user/src/main/java/com/sparta/hotdeal/user/application/service/AuthService.java
@@ -51,8 +51,8 @@ public class AuthService {
         String encodedPassword = passwordEncoder.encode(requestDto.getPassword());
 
         User user = requestDto.toEntity(encodedPassword);
-        user.updateCreatedByAndUpdateBy(user.getEmail());
         userRepository.save(user);
+        user.updateCreatedByAndUpdateBy(user.getEmail());
 
         return ResPostSignUpDto.builder()
                 .userId(user.getUserId())

--- a/user/src/main/java/com/sparta/hotdeal/user/infrastructure/security/SecurityAuditorAware.java
+++ b/user/src/main/java/com/sparta/hotdeal/user/infrastructure/security/SecurityAuditorAware.java
@@ -2,6 +2,7 @@ package com.sparta.hotdeal.user.infrastructure.security;
 
 import java.util.Optional;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -9,13 +10,14 @@ import org.springframework.stereotype.Component;
 public class SecurityAuditorAware implements AuditorAware<String> {
     @Override
     public Optional<String> getCurrentAuditor() {
-        RequestUserDetails userDetails = (RequestUserDetails) SecurityContextHolder.getContext()
-                .getAuthentication().getPrincipal();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (userDetails != null) {
-            return Optional.of(userDetails.getEmail());
+        if (authentication.getPrincipal() instanceof String) {
+            return Optional.of("anonymousUser");
         }
 
-        return Optional.of("anonymousUser");
+        RequestUserDetails userDetails = (RequestUserDetails) authentication.getPrincipal();
+
+        return Optional.of(userDetails.getEmail());
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- fix/65/auditing-user -> develop
### 이슈
- Resolves #65 
### Description
- Principal이 String인 경우 RequestUserDetails로 캐스팅하지 않고 String을 리턴하도록 변경
- authService의 회원가입 메서드의 auditing 필드 업데이트 메서드를 save 후에 호출하도록 변경
### To Reviewers
- Auditing 관련 버그 수정입니다.
